### PR TITLE
Add Windows 11 to docs/directory_structure.md

### DIFF
--- a/docs/directory_structure.md
+++ b/docs/directory_structure.md
@@ -19,14 +19,14 @@ your operating system:
     - Windows:
         - `C:\My Documents\OpenTTD` (95, 98, ME)
         - `C:\Documents and Settings\<username>\My Documents\OpenTTD` (2000, XP)
-        - `C:\Users\<username>\Documents\OpenTTD` (Vista, 7, 8.1, 10)
+        - `C:\Users\<username>\Documents\OpenTTD` (Vista, 7, 8.1, 10, 11)
     - macOS: `~/Documents/OpenTTD`
     - Linux: `$XDG_DATA_HOME/openttd` which is usually `~/.local/share/openttd`
        when built with XDG base directory support, otherwise `~/.openttd`
 3. The shared directory
     - Windows:
         - `C:\Documents and Settings\All Users\Shared Documents\OpenTTD` (2000, XP)
-        - `C:\Users\Public\Documents\OpenTTD` (Vista, 7, 8.1, 10)
+        - `C:\Users\Public\Documents\OpenTTD` (Vista, 7, 8.1, 10, 11)
     - macOS: `/Library/Application Support/OpenTTD`
     - Linux: not available
 4. The binary directory (where the OpenTTD executable is)


### PR DESCRIPTION
## Motivation / Problem

Microsoft has released Windows 11 and the documentation does not describe the directory structure for Windows 11, but it looks to be the same as on Windows 11

## Description

In docs/directory_structure.md, changed every `Windows (Vista, 7, 8.1, 10)` to `Windows (Vista, 7, 8.1, 10, 11)` (because I am playing it on Windows 11 and the structure is the same as on Windows 10).

## Limitations

:green_circle: I don't found any limitations in this fix.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested') **NO**
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md) **NO**
* This PR affects the save game format? (label 'savegame upgrade') **NO**
* This PR affects the GS/AI API? (label 'needs review: Script API') **NO**
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF') **NO**
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
